### PR TITLE
fix(toast): globally import sonner styles

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,52 @@
+# Project Overview
+
+This is a personal website and blog built with [Astro](https://astro.build/). It's designed to be simple, fast, and includes features like a Vim-style keyboard navigation, auto OS-theme detection, and smooth page transitions using the View Transitions API.
+
+The project uses [Tailwind CSS](https://tailwindcss.com/) for styling and [React](https://react.dev/) as a UI framework integrated with Astro. Content is managed through Astro's content collections, with blog posts written in Markdown and project data in JSON files.
+
+## Building and Running
+
+To get started with this project, you'll need to have [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/) installed.
+
+1.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+2.  **Run the development server:**
+    ```bash
+    npm run dev
+    ```
+    This will start a local development server, typically at `http://localhost:4321`.
+
+3.  **Build the project:**
+    ```bash
+    npm run build
+    ```
+    This will create a production-ready build of the website in the `dist/` directory.
+
+4.  **Preview the build:**
+    ```bash
+    npm run preview
+    ```
+    This will start a local server to preview the production build.
+
+## Development Conventions
+
+### Content
+
+*   **Blog Posts:** To add a new blog post, create a new Markdown file (`.md`) in the `src/content/blog/` directory. The file's frontmatter must include a `title` and a `date`.
+*   **Projects:** To add a new project, create a new JSON file (`.json`) in the `src/content/projects/` directory. The JSON file should follow the schema defined in `src/content.config.ts`.
+*   **Visions:** To add a new vision, create a new Markdown file (`.md`) in the `src/content/vision/` directory. The file's frontmatter must include a `title` and a `date`.
+
+### Pages
+
+To add a new static page, create a new `.astro` file in the `src/pages/` directory. For example, creating `src/pages/about.astro` will make it available at the `/about` URL. It's recommended to use the `src/layouts/base.astro` layout for a consistent look and feel.
+
+### Styling
+
+The project uses Tailwind CSS for styling. You can find the global styles in `src/styles/global.css`.
+
+### Vim-style Keyboard Navigation
+
+The `src/scripts/vim.ts` file implements a Vim-style keyboard navigation system. This script is initialized in `src/layouts/base.astro` and is available on all pages.

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,8 @@
 
 ### P0
 
+- [ ] Toast is inconsistent, when it's in other than the home page.
+
 ### P1
 
 ### P2
@@ -13,7 +15,6 @@
 ## Done
 
 - [x] Fix toast notification bug where toast appears on a left top without the UI
-
 - [x] Popup to show the vim bindings help (vim-help.astro) Currently Disabled since not prioritized
   - [x] Modal implemented with styling and keyboard shortcuts (? to open, q/Esc to close)
   - [x] Fix: click-outside backdrop to close doesn't work

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
+@import "sonner/dist/styles.css";
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @source "../**/*.astro";


### PR DESCRIPTION
The toast notifications were appearing unstyled after a client-side navigation. This was because the styles for the  component were not being re-applied after a page transition.

This commit fixes the issue by importing the  styles globally in the  file. This ensures that the styles are
always available, regardless of the page you are on.