### PR TITLE
feat: enhance vim navigation and simplify shortcuts modal

### DIFF
--- a/src/components/vim-help.astro
+++ b/src/components/vim-help.astro
@@ -6,61 +6,44 @@ const { id } = Astro.props;
 ---
 
 <!-- Modal to show Vim help of this website -->
-<dialog 
-  id={id} 
-  tabindex="-1" 
+<dialog
+  id={id}
+  tabindex="-1"
   aria-modal="true"
   aria-labelledby={`${id}-title`}
-  class="rounded-lg bg-(--color-background) dark:bg-(--color-background-dark) p-8 max-w-md w-full backdrop:bg-black backdrop:opacity-50 fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 outline-none"
+  class="rounded-lg bg-(--color-background) dark:bg-(--color-background-dark) p-6 max-w-2xl w-full backdrop:bg-black backdrop:opacity-50 dark:backdrop:opacity-90 fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 outline-none"
 >
     <div class="relative">
-        <span class="absolute top-0 right-0 group">
-            <button
-                id={`${id}-close-button`}
-                class="text-(--color-text-third) dark:text-(--color-text-third-dark) hover:text-(--color-text-first) dark:hover:text-(--color-text-first-dark) text-2xl leading-none"
-                aria-label="Close"
-            >
-                ×
-            </button>
-            <span class="absolute bottom-full right-0 mb-2 px-2 py-1 text-xs bg-(--color-text-first) dark:bg-(--color-text-first-dark) text-(--color-background) dark:text-(--color-background-dark) rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap">
-                q or Esc to close
-            </span>
-        </span>
+        <button
+            id={`${id}-close-button`}
+            class="absolute top-0 right-0 text-(--color-text-third) dark:text-(--color-text-third-dark) hover:text-(--color-text-first) dark:hover:text-(--color-text-first-dark) text-sm"
+            aria-label="Close"
+        >
+            Esc to close
+        </button>
 
         <h2 id={`${id}-title`} class="text-xl font-bold mb-4 text-(--color-text-first) dark:text-(--color-text-first-dark)">
-            Keyboard Shortcuts
+            Shortcuts
         </h2>
 
-        <div class="space-y-4 text-base text-(--color-text-second) dark:text-(--color-text-second-dark)">
-            <div>
-                <h3 class="font-semibold mb-2 text-(--color-text-first) dark:text-(--color-text-first-dark)">Navigation</h3>
-                <ul class="space-y-1">
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">h</kbd> Home</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">b</kbd> Blog</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">p</kbd> Projects</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">v</kbd> Vision</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">c</kbd> Club</li>
-                </ul>
-            </div>
+        <div class="grid grid-cols-2 gap-8 text-base text-(--color-text-second) dark:text-(--color-text-second-dark)">
+            <ul class="space-y-1">
+                <li>h — Home</li>
+                <li>b — Blog</li>
+                <li>p — Projects</li>
+                <li>v — Vision</li>
+                <li>c — Club</li>
+                <li>y — Copy URL</li>
+            </ul>
 
-            <div>
-                <h3 class="font-semibold mb-2 text-(--color-text-first) dark:text-(--color-text-first-dark)">Scrolling</h3>
-                <ul class="space-y-1">
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">gg</kbd> Scroll to top</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">G</kbd> Scroll to bottom</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">u</kbd> Scroll up half page</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">d</kbd> Scroll down half page</li>
-                </ul>
-            </div>
-
-            <div>
-                <h3 class="font-semibold mb-2 text-(--color-text-first) dark:text-(--color-text-first-dark)">Other</h3>
-                <ul class="space-y-1">
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">y</kbd> Copy current URL</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">?</kbd> Show this help</li>
-                    <li><kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">q</kbd> or <kbd class="px-2 py-1 bg-(--color-text-third) dark:bg-(--color-text-third-dark) text-(--color-background) dark:text-(--color-background-dark) rounded text-xs">Esc</kbd> Close this help</li>
-                </ul>
-            </div>
+            <ul class="space-y-1">
+                <li>j — Scroll down</li>
+                <li>k — Scroll up</li>
+                <li>u — Scroll up half page</li>
+                <li>d — Scroll down half page</li>
+                <li>gg — Scroll to top</li>
+                <li>G — Scroll to bottom</li>
+            </ul>
         </div>
     </div>
 </dialog>
@@ -75,7 +58,7 @@ const { id } = Astro.props;
 
         // Focus trap implementation
         let focusableElements = [];
-        
+
         function getFocusableElements() {
             const selector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
             return Array.from(dialog.querySelectorAll(selector));
@@ -83,7 +66,7 @@ const { id } = Astro.props;
 
         function trapFocus(event) {
             if (event.key !== 'Tab') return;
-            
+
             focusableElements = getFocusableElements();
             if (focusableElements.length === 0) return;
 
@@ -114,7 +97,7 @@ const { id } = Astro.props;
             focusableElements = getFocusableElements();
             const firstFocusable = focusableElements[0] || closeButton;
             if (firstFocusable) firstFocusable.focus();
-            
+
             // Add focus trap listener
             dialog.addEventListener('keydown', trapFocus);
         }
@@ -123,7 +106,7 @@ const { id } = Astro.props;
         function handleDialogClose() {
             // Remove focus trap listener
             dialog.removeEventListener('keydown', trapFocus);
-            
+
             // Restore focus to help button
             if (helpButton) {
                 helpButton.focus();

--- a/src/scripts/vim.ts
+++ b/src/scripts/vim.ts
@@ -73,7 +73,7 @@ const KEY_TIMEOUT = 500; // milliseconds
 /**
  * Handle global Vim key bindings
  * Navigation: h/p/b/c/v
- * Scrolling: gg/G/u/d
+ * Scrolling: j/k/gg/G/u/d
  *
  * @param event The keyboard event
  * @returns true if a binding was executed, false otherwise
@@ -115,7 +115,7 @@ function handleGlobalBindings(event: KeyboardEvent): boolean {
         // Execute 'gg' command
         lastKey = "";
         lastKeyTime = 0;
-        window.scrollTo({ top: 0, behavior: "smooth" });
+        window.scrollTo({ top: 0, behavior: "auto" });
         return true;
       }
 
@@ -123,7 +123,7 @@ function handleGlobalBindings(event: KeyboardEvent): boolean {
       // 'G' jumps to bottom
       window.scrollTo({
         top: document.documentElement.scrollHeight,
-        behavior: "smooth",
+        behavior: "auto",
       });
       return true;
 
@@ -131,7 +131,7 @@ function handleGlobalBindings(event: KeyboardEvent): boolean {
       // 'u' scrolls up half page (Ctrl+u in Vim)
       window.scrollBy({
         top: -1 * (window.innerHeight / 2),
-        behavior: "smooth",
+        behavior: "auto",
       });
       return true;
 
@@ -139,9 +139,26 @@ function handleGlobalBindings(event: KeyboardEvent): boolean {
       // 'd' scrolls down half page (Ctrl+d in Vim)
       window.scrollBy({
         top: window.innerHeight / 2,
-        behavior: "smooth",
+        behavior: "auto",
       });
       return true;
+
+    case "j":
+      // 'j' scrolls down
+      window.scrollBy({
+        top: window.innerHeight / 20,
+        behavior: "auto",
+      });
+      return true;
+
+    case "k":
+      // 'k' scrolls up
+      window.scrollBy({
+        top: -1 * (window.innerHeight / 20),
+        behavior: "auto",
+      });
+      return true;
+
     case "y":
       // 'y' copies current URL to clipboard
       navigator.clipboard.writeText(window.location.href);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 @source "../**/*.astro";
 
 @theme {
-  --color-background: #f0f0f0;
+  --color-background: #f1f1f1;
   --color-text-first: #000000;
   --color-text-second: #333333;
   --color-text-third: #666666;
@@ -20,11 +20,6 @@
 }
 
 @layer base {
-  /* Global smooth scrolling behavior */
-  html {
-    scroll-behavior: smooth;
-  }
-
   /* Focus states for keyboard navigation accessibility */
   a:focus-visible,
   button:focus-visible {


### PR DESCRIPTION
- Add j/k keybindings for line-by-line scrolling (window.innerHeight/20)
- Convert all scroll operations to instant behavior ('auto') instead of smooth
- Remove global CSS smooth-scrolling to fix key repeat issues
- Simplify shortcuts modal design:
  * Remove section titles and kbd styling boxes
  * Use em-dash separators and clean two-column layout
  * Replace × button with 'Esc to close' text
  * Remove redundant shortcuts (? and q/Esc descriptions)
- Make backdrop opacity conditional: 50% (light) / 90% (dark)
- Update light mode background to #f1f1f1